### PR TITLE
py2bit.c: fix pointer bug flagged by gcc-14.

### DIFF
--- a/py2bit.c
+++ b/py2bit.c
@@ -32,7 +32,7 @@ error:
 }
 
 PyObject *py2bitEnter(pyTwoBit_t *self, PyObject *args) {
-    pyTwoBit_t *pytb = self->tb;
+    pyTwoBit_t *pytb = self;
 
     if(!pytb) {
         PyErr_SetString(PyExc_RuntimeError, "The 2bit file handle is not open!");


### PR DESCRIPTION
Since gcc 14, a whole range of warnings have become errors, notably the casting from incompatible pointer types.  In the case of py2bit, this seems to flag a real pointer arithmetic bug.  The symptom on build time is:

	py2bit.c:35:24: error: initialization of ‘pyTwoBit_t *’ from incompatible pointer type ‘TwoBit *’ [-Wincompatible-pointer-types]
	   35 |     pyTwoBit_t *pytb = self->tb;
	      |                        ^~~~

Transmitting the self pointer straight to the pytb pointer newly created without referencing to the TwoBit_t pointer fixes the issue.

This was initially reported under [Debian bug #1075421] by Matthias Klose.

[Debian bug #1075421]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075421